### PR TITLE
Fix signin wallpaper image resize issue

### DIFF
--- a/resources/views/signin.blade.php
+++ b/resources/views/signin.blade.php
@@ -7,8 +7,15 @@
         max-width: 50%;
         height: auto;
     }
+    .bg-cover {
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        width: 100%;
+        height: 100%;
+    }
 </style>
-<div class="container-fuild">
+<div class="container-fluid">
     <div class=" w-100 overflow-hidden position-relative flex-wrap d-block vh-100">
         <div class="row">
             <div class="col-lg-4 col-md-12 col-sm-12">
@@ -84,7 +91,7 @@
                     }
                     $bgSrc = $candidate ? asset($candidate) : URL::asset('/build/img/bg/chatlogo.jpg');
                     @endphp
-                    <img src="{{ $bgSrc }}" class="w-100 h-100 object-fit-cover" alt="Login Background">
+                    <div class="w-100 h-100 bg-cover" style="background-image: url('{{ $bgSrc }}');"></div>
                 </div>
             </div>
 


### PR DESCRIPTION
Refactor wallpaper display in signin page to consistently cover the 8-column area.

The previous `<img>` with `object-fit-cover` was not reliably filling the 8-column space, leading to blank areas on the right side. Switching to a `div` with `background-image` and `background-size: cover` ensures the wallpaper always fills the available space correctly. Also fixed a typo in `container-fluid`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7758b78-c281-4315-bab5-e0170334ef48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7758b78-c281-4315-bab5-e0170334ef48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

