### PR TITLE
Fix user email uniqueness validation on edit

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -129,13 +129,38 @@ public function store(Request $request)
 }
 public function updateEmail(Request $request)
 {
-    $request->validate([
-        'new_email' => 'required|email|unique:users,email',
-    ]);
+        $user = auth()->user();
 
-    $user = auth()->user();
-    $user->email = $request->new_email;
-    $user->save();
+        $request->validate([
+            'new_email' => [
+                'required',
+                'email',
+                function ($attribute, $value, $fail) use ($user) {
+                    // Allow keeping the same email
+                    if ($user && $user->email === $value) {
+                        return;
+                    }
+
+                    try {
+                        $objectId = new \MongoDB\BSON\ObjectId($user->_id ?? $user->id);
+                        $exists = \App\Models\User::where('email', $value)
+                            ->where('_id', '!=', $objectId)
+                            ->exists();
+                    } catch (\Throwable $e) {
+                        $exists = \App\Models\User::where('email', $value)
+                            ->where('_id', '!=', ($user->_id ?? $user->id))
+                            ->exists();
+                    }
+
+                    if ($exists) {
+                        $fail('The email has already been taken.');
+                    }
+                },
+            ],
+        ]);
+
+        $user->email = $request->new_email;
+        $user->save();
 
     return back()->with('success', 'Email updated successfully.');
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -163,11 +163,20 @@ class UsersController extends Controller
         $ignoreId = $request->query('ignore_id');
         $exists = false;
         if ($email !== '') {
-            $query = User::where('email', $email);
             if (!empty($ignoreId)) {
-                $query->where('_id', '!=', $ignoreId);
+                try {
+                    $objectId = new ObjectId($ignoreId);
+                    $exists = User::where('email', $email)
+                        ->where('_id', '!=', $objectId)
+                        ->exists();
+                } catch (\Throwable $e) {
+                    $exists = User::where('email', $email)
+                        ->where('_id', '!=', $ignoreId)
+                        ->exists();
+                }
+            } else {
+                $exists = User::where('email', $email)->exists();
             }
-            $exists = $query->exists();
         }
         return response()->json(['exists' => $exists]);
     }


### PR DESCRIPTION
Update email uniqueness validation to correctly ignore the current user's ID during edit operations.

Previously, when editing a user's profile or updating the authenticated user's email, the uniqueness validation would incorrectly flag the user's own existing email as a duplicate, preventing the update. This change ensures that the validation properly excludes the current user's ID from the uniqueness check, allowing updates where the email remains unchanged or is unique among *other* users.

---
<a href="https://cursor.com/background-agent?bcId=bc-08ceb5cd-433a-485f-a08b-9fc8155ee904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08ceb5cd-433a-485f-a08b-9fc8155ee904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

